### PR TITLE
radiomix/download-lambdas/v0.39.0

### DIFF
--- a/modules/download-lambda/.terraform.lock.hcl
+++ b/modules/download-lambda/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.75.1"
+  constraints = "~> 3.38"
+  hashes = [
+    "h1:++H0a4igODgreQL3SJuRz71JZkC69rl41R8xLYM894o=",
+    "zh:11c2ee541ca1da923356c9225575ba294523d7b6af82d6171c912470ef0f90cd",
+    "zh:19fe975993664252b4a2ff1079546f2b186b01d1a025a94a4f15c37e023806c5",
+    "zh:442e7fc145b2debebe9279b283d07f5f736dc1776c2e5b1702728a6eb03789d0",
+    "zh:7a77991b204ae2c16ac29a32226135d5fdbda40c8dafa77c5adf5439a346be77",
+    "zh:89a257933181c15293c15a858fbfe7252129cc57cc2ec05b6c0b595d1bfe9d38",
+    "zh:b1813ea5b6b0fd88ea85b1b21b8e4119566d1bc34feca297b4fb39d0536893cb",
+    "zh:c519f3292ae431bd2381f88a95bd37c52f7a56d91feef88511e929344c180549",
+    "zh:d3dbe88b661c073c174f04f73adc2720372143bdfa12f4fe8f411332e64662cf",
+    "zh:e92a27e3c7295b031b5d62dd9428966c96e3157fc768b3d848a9ac60d1661c8e",
+    "zh:ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8",
+    "zh:ed6ce1f9fa96aa28dd65842f852abed25f919d20b5cf53d26cec5b3f4d845725",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.0.0"
   hashes = [

--- a/modules/download-lambda/terraform.tfstate
+++ b/modules/download-lambda/terraform.tfstate
@@ -1,0 +1,75 @@
+{
+  "version": 4,
+  "terraform_version": "1.1.8",
+  "serial": 1,
+  "lineage": "98aeb740-9fb9-86e4-2fdd-8b24d26b4533",
+  "outputs": {
+    "files": {
+      "value": [
+        "runners.zip",
+        "runner-binaries-syncer.zip",
+        "webhook.zip"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string",
+          "string"
+        ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "download",
+      "provider": "provider[\"registry.terraform.io/hashicorp/null\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "8729198591320211475",
+            "triggers": {
+              "file": "runners.zip",
+              "name": "runners",
+              "tag": "v0.39.0"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "id": "2056920406632824632",
+            "triggers": {
+              "file": "runner-binaries-syncer.zip",
+              "name": "runner-binaries-syncer",
+              "tag": "v0.39.0"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "id": "1617486467651423444",
+            "triggers": {
+              "file": "webhook.zip",
+              "name": "webhook",
+              "tag": "v0.39.0"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/modules/download-lambda/variables.tf
+++ b/modules/download-lambda/variables.tf
@@ -10,4 +10,19 @@ variable "lambdas" {
     name = string
     tag  = string
   }))
+  // download from: https://github.com/philips-labs/terraform-aws-github-runner/releases
+  default = [
+    {
+      name = "runners"
+      tag  = "v0.39.0"
+    },
+    {
+      name = "runner-binaries-syncer"
+      tag  = "v0.39.0"
+    },
+    {
+      name = "webhook"
+      tag  = "v0.39.0"
+    }
+  ]
 }


### PR DESCRIPTION
### Set lambda binary version/tag to `v0.39.0`
### Download lambdas locally to `modules/download-lambda`