### PR TITLE
radiomix/packer/build/linux-amzn2

### DIFF
--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -78,6 +78,7 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+# AWS credential profile to use during packer run
 variable "aws_profile" {
   description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages"
   type        = string
@@ -85,6 +86,7 @@ variable "aws_profile" {
 }
 
 source "amazon-ebs" "githubrunner" {
+  profile                     = var.aws_profile
   ami_name                    = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
   instance_type               = var.instance_type
   region                      = var.region

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -78,6 +78,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "aws_profile" {
+  description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages"
+  type        = string
+  default     = "aws-02-im7"
+}
+
 source "amazon-ebs" "githubrunner" {
   ami_name                    = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
   instance_type               = var.instance_type


### PR DESCRIPTION
### Packer build an AWS/AMZ linux AMI
- set variable `aws_profile` to point to the AWS credential profile in ~/.aws/config`
- run `packer build github_agent.linux.pkr.hcl`
<pre><font color="#00AA00"><b>==&gt; githubactions-runner.amazon-ebs.githubrunner: Adding tags to AMI (ami-06b35b10c66c54030)...</b></font>
<font color="#00AA00"><b>==&gt; githubactions-runner.amazon-ebs.githubrunner: Tagging snapshot: snap-05d6fc82b3e4ec9dc</b></font>
<font color="#00AA00"><b>==&gt; githubactions-runner.amazon-ebs.githubrunner: Creating AMI tags</b></font>
<font color="#00AA00">    githubactions-runner.amazon-ebs.githubrunner: Adding tag: &quot;Release&quot;: &quot;Latest&quot;</font>
<font color="#00AA00">    githubactions-runner.amazon-ebs.githubrunner: Adding tag: &quot;Base_AMI_Name&quot;: &quot;amzn2-ami-kernel-5.10-hvm-2.0.20220316.0-x86_64-gp2&quot;</font>
<font color="#00AA00">    githubactions-runner.amazon-ebs.githubrunner: Adding tag: &quot;OS_Version&quot;: &quot;amzn2&quot;</font>
<font color="#00AA00"><b>==&gt; githubactions-runner.amazon-ebs.githubrunner: Creating snapshot tags</b></font>
</pre>