### PR TITLE
radiomix/GH-app-secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ secrets.auto.tfvars
 .vscode
 
 **/coverage/*
+
+# secrets (GH app keyes)
+.secrets/


### PR DESCRIPTION
### Ignore GH app secrets in .secrets/
We generate a GH app pem and save it under folder `.secrets/`, but we don't want to commit it into the repository.
- update `.gitignore` to ignore folder `.secrets/`

See documentation in https://github.com/philips-labs/terraform-aws-github-runner#setup-github-app-part-1
```
1)Setup GitHub App (part 1)

Go to GitHub and [create a new app](https://docs.github.com/en/developers/apps/creating-a-github-app)[](https://github.com/philips-labs/terraform-aws-github-runner#setup-terraform-module). Beware you can create apps your organization or for a user. For now we support only organization level apps.

    Create app in Github
    Choose a name
    Choose a website (mandatory, not required for the module).
    Disable the webhook for now (we will configure this later or create an alternative webhook).
    Permissions for all runners:
        Repository:
            Actions: Read-only (check for queued jobs)
            Checks: Read-only (receive events for new builds)
            Metadata: Read-only (default/required)
    Permissions for repo level runners only:
        Repository:
            Administration: Read & write (to register runner)
    Permissions for organization level runners only:
        Organization
            Self-hosted runners: Read & write (to register runner)
    Save the new app.
    On the General page, make a note of the "App ID" and "Client ID" parameters.
    Generate a new private key and save the app.private-key.pem file.
```