### PR TITLE
radiomix/GHA/downgrade-checkout-back-to-v4

### DIFF
--- a/.github/workflows/lambda-runner-binaries-syncer.yml
+++ b/.github/workflows/lambda-runner-binaries-syncer.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: modules/runner-binaries-syncer/lambdas/runner-binaries-syncer
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install
       - name: Run prettier

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: modules/runners/lambdas/runners
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install
       - name: Run prettier

--- a/.github/workflows/lambda-webhook.yml
+++ b/.github/workflows/lambda-webhook.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: modules/webhook/lambdas/webhook
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: yarn install
       - name: Run prettier

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: images/${{ matrix.image }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       
       - name: packer init
         run: packer init .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           LAMBDA: ${{ matrix.lambda }}
         run: echo ::set-output name=name::${LAMBDA##*/}
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Add zip
         run: apt update && apt install zip
       - name: Build dist
@@ -39,7 +39,7 @@ jobs:
     needs:
       prepare
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -21,7 +21,7 @@ jobs:
       image: hashicorp/terraform:${{ matrix.terraform }}
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: "Fake zip files" # Validate will fail if it cannot find the zip files
         run: |
           touch modules/webhook/lambdas/webhook/webhook.zip
@@ -53,7 +53,7 @@ jobs:
     container:
       image: hashicorp/terraform:${{ matrix.terraform }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: terraform init
         run: terraform init -get -backend=false -input=false
       - if: contains(matrix.terraform, '1.1.')


### PR DESCRIPTION
## Downgrade actions/checkout to v4 to force Nodejs 20


CI stopped working after bumping `checkout` to `v5`

The CI workflows (terraform.yml and packer-build.yml) use actions/checkout@v5 inside Alpine Linux containers (Terraform and Packer Docker images). actions/checkout@v5 requires Node.js 24, which depends on pthread_getname_np — a symbol not available in the musl libc environment of Alpine Linux. This causes 
`Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found` ❌ 
